### PR TITLE
Fix typo: @assett -> @assert in generate.jl

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -21,7 +21,7 @@ const OP_TO_NODE = Dict(:+ => ElementNode("plus"),
     :cos => ElementNode("cos"))
 
 function _symbol_to_MathML(e::Expr)
-    @assett e.head in (:call, :invoke)
+    @assert e.head in (:call, :invoke)
     elm = ElementNode("apply")
     for arg in @views e.args[2:end]
         if arg isa Expr


### PR DESCRIPTION
## Summary
- Fixed typo `@assett` → `@assert` in `src/generate.jl:24` that prevented package from loading

## Interface Compatibility Analysis

As part of an interface check task, I tested MathML.jl for compatibility with Julia's standard interfaces and SciML's array/number interfaces.

### Findings

1. **JLArrays/GPU array testing is NOT applicable** - MathML.jl is a parsing library that transforms MathML XML into Symbolics.jl expressions. It does not perform numerical computations on arrays.

2. **BigFloat compatibility observations**:
   - `parse_cn` uses `parse(Float64, ...)` - hardcoded for CellML compatibility (intentional)
   - `ϵ = eps(Float64)` - used for comparison operations (by design)
   - These are not interface violations since MathML is a parsing library, not a generic numerical library

3. **Critical bug found**: The `@assett` typo in `generate.jl` prevents the package from loading with `UndefVarError: @assett not defined in MathML`

4. **Pre-existing test failure**: One test fails due to Symbolics returning `NaNMath.pow(x, y)` instead of `x^y` - this is a Symbolics version compatibility issue, not related to interface compliance.

## Test plan
- [x] Package loads successfully after fix
- [x] Verified the typo was present on main branch (package could not precompile)

CC @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)