### PR TITLE
Bump version to 0.1.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MathML"
 uuid = "abcecc63-2b08-419c-80c4-c63dca6fa478"
 authors = ["anand <anandj@uchicago.edu> and contributors"]
-version = "0.1.17"
+version = "0.1.18"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
## Version Bump

Bumping version from 0.1.17 to 0.1.18 to prepare for release.

### Changes since last release (v0.1.17)

- Fix typo: `@assett` -> `@assert` in `_symbol_to_MathML` (#81)
- Migrate to Dependabot from CompatHelper (#79)
- Bump actions/checkout from 4 to 6 (#78)
- Add downgrade CI workflow (#67)
- Fix spelling typos (#66)
- Add .typos.toml configuration + SpellCheck.yml workflow (#65)
- Remove Invalidations.yml GitHub action workflow

### Registration Command

After merging, register with:

@JuliaRegistrator register

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)