### PR TITLE
Bump version to 0.1.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathML"
 uuid = "abcecc63-2b08-419c-80c4-c63dca6fa478"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["anand <anandj@uchicago.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary
- Bumps version from 0.1.18 to 0.1.19 so the Symbolics 7 compat added in #91 gets registered
- Without this release, downstream packages like CellMLToolkit cannot resolve ModelingToolkit 11 which requires Symbolics 7
- The registered 0.1.18 only has `Symbolics = "3 - 6"` in the General registry

## Test plan
- [ ] CI passes
- [ ] JuliaRegistrator registers the new version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)