### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,10 @@ on:
 jobs:
   test:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: Downgrade
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic Format Check"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -5,9 +5,5 @@ on: [pull_request]
 jobs:
   typos-check:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,8 @@
+# External CellML/MathML model fixtures contain verbatim variable names (e.g. denomMgpHODE)
+# that are not English prose and must not be "corrected".
+[files]
+extend-exclude = ["test/data/"]
+
 [default.extend-words]
 # MathML
 parser = "parser"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Converts the remaining inline CI jobs to the centralized SciML `.github` reusable workflows (`@v1`), each with `secrets: "inherit"`. Brings MathML.jl fully in line with the Sundials.jl end-state (Tests, Documentation, Runic, SpellCheck, Downgrade all via central callers).

## Converted (inline -> central)
- `FormatCheck.yml`: `fredrikekre/runic-action` -> `runic.yml@v1`
- `SpellCheck.yml`: `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`
- `Downgrade.yml`: inline `julia-downgrade-compat` -> `downgrade.yml@v1` (preserves `if: false`, `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`)

## Already central (left as-is, `secrets: "inherit"` confirmed)
- `Tests.yml` -> `tests.yml@v1` (matrix `1`, `lts`, `pre` preserved)
- `Documentation.yml` -> `documentation.yml@v1`

## Other changes
- `dependabot.yml`: removed the `crate-ci/typos` version-update ignore (no longer applicable now that typos runs via the central caller); `github-actions` (weekly, `/`) and `julia` (daily, group `all-julia-packages: ["*"]`, dirs `/`, `/docs`, `/test`) blocks preserved.
- `.typos.toml`: added `[files] extend-exclude = ["test/data/"]` to skip external CellML/MathML model fixtures whose verbatim variable names (e.g. `denomMgpHODE`) are false positives. No prose was edited.

## Verification
- Runic 1.7.0 run in-place: no changes (repo already ran Runic inline, already clean).
- `typos .` exits 0 with the new exclude.
- All changed YAML validated with `yaml.safe_load`.

**Typos fixed:** 0 (only false-positive fixture identifiers, handled via exclude).
**Runic formatting applied:** no (already clean).

## Heads up
Job/check names change with the move to reusable workflows, so any branch-protection required status checks will need to be updated to the new check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)