### PR TITLE
Use SciMLTesting v1.0.0 (run_tests harness)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ EzXML = "1.1"
 IfElse = "0.1.1"
 ModelingToolkit = "11"
 PrecompileTools = "1.2.1"
+SciMLTesting = "1"
 SpecialFunctions = "2"
 Statistics = "1"
 Symbolics = "7.2"
@@ -27,8 +28,8 @@ Test = "1"
 julia = "1.10"
 [extras]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ModelingToolkit", "Pkg"]
+test = ["Test", "ModelingToolkit", "SciMLTesting"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,27 +1,27 @@
-using Pkg
 using MathML, EzXML, Symbolics, SpecialFunctions, IfElse, AbstractTrees, Test
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "All")
-
-if GROUP == "QA"
-    Pkg.activate("qa")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    Pkg.instantiate()
-    include("qa/qa.jl")
-else
-    @testset "MathML.jl" begin
-        @testset "parsing" begin
-            include("parse.jl")
+run_tests(;
+    core = () -> begin
+        @testset "MathML.jl" begin
+            @testset "parsing" begin
+                include("parse.jl")
+            end
+            @testset "utils" begin
+                include("utils.jl")
+            end
+            @testset "print" begin
+                include("print.jl")
+            end
+            @testset "generate" begin
+                include("generate.jl")
+            end
+            # @testset "systems" begin include("sys.jl") end
         end
-        @testset "utils" begin
-            include("utils.jl")
-        end
-        @testset "print" begin
-            include("print.jl")
-        end
-        @testset "generate" begin
-            include("generate.jl")
-        end
-        # @testset "systems" begin include("sys.jl") end
-    end
-end
+    end,
+    groups = Dict(
+        "QA" => (; env = joinpath(@__DIR__, "qa"), body = () -> begin
+            include(joinpath(@__DIR__, "qa", "qa.jl"))
+        end),
+    ),
+)


### PR DESCRIPTION
Replaces the hand-written `GROUP`-dispatch in `test/runtests.jl` with a single `SciMLTesting.run_tests(...)` call (SciMLTesting v1.0.0).

## Shape
Single-package, `GROUP`-dispatched (`QA` vs everything-else), QA in an isolated `test/qa` sub-env, default `GROUP="All"`.

## Mapping (behavior-equivalent)
- `core` = thunk reproducing the original `else`-branch verbatim: the `@testset "MathML.jl"` block (`parsing`/`utils`/`print`/`generate`, with the same commented-out `systems`). The original `else` ran for any non-`QA` group; `run_tests` runs `core` for `All`, `Core`, and any unknown fallthrough — same set.
- `QA` = `groups["QA"]` with a declared `env = test/qa`, so it is **not** run under `"All"` and is selectable only via `GROUP="QA"`, matching the original `if GROUP == "QA"`. The QA body (custom Aqua kwargs + `@test_broken` placeholders tracking SciML/MathML.jl#104) is kept verbatim via `include`, not collapsed into `run_qa`.

Routing verified: unset→core, All→core, Core→core, QA→qa, unknown→core.

## Project.toml
- `[extras]`/`[targets].test`/`[compat]`: add `SciMLTesting` (UUID `09d9d899-...`), drop `Pkg` (only the old harness used it).
- Note: `test/qa/qa.jl` has a `@test_broken false` comment referencing "`[extras] Pkg` missing `[compat]` entry". With `Pkg` now removed from `[extras]`, that specific Aqua `deps_compat` finding no longer exists, but `deps_compat = false` already disables the check and the `@test_broken false` placeholder is unaffected — the QA assertions are unchanged. The comment is left as-is to avoid touching the QA body; reviewer may wish to prune the stale parenthetical.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)