### PR TITLE
Canonicalize tests to @safetestset for module isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ EzXML = "1.1"
 IfElse = "0.1.1"
 ModelingToolkit = "11"
 PrecompileTools = "1.2.1"
+SafeTestsets = "0.1, 1"
 SpecialFunctions = "2"
 Statistics = "1"
 Symbolics = "7.2"
@@ -28,7 +29,8 @@ julia = "1.10"
 [extras]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ModelingToolkit", "Pkg"]
+test = ["Test", "ModelingToolkit", "Pkg", "SafeTestsets"]

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -1,3 +1,5 @@
+using MathML, Test
+
 ex = :(1 + 2 + x + y * z * num^4)
 io = IOBuffer()
 print(io, to_MathML(ex))

--- a/test/print.jl
+++ b/test/print.jl
@@ -1,3 +1,5 @@
+using MathML, EzXML, AbstractTrees, Test
+
 xml = readxml("data/math.xml").root
 
 io = IOBuffer()

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,6 +3,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MathML = "abcecc63-2b08-419c-80c4-c63dca6fa478"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,5 +12,6 @@ MathML = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,7 @@
-using MathML, Aqua, JET, Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using MathML, Aqua, Test
     # deps_compat (extras: Pkg has no [compat] entry) and piracies (children/nodetype/printnode
     # on EzXML.Node) are genuine findings tracked in
     # https://github.com/SciML/MathML.jl/issues/104 — run the rest of Aqua, mark these broken.
@@ -9,7 +10,8 @@ using MathML, Aqua, JET, Test
     @test_broken false  # Aqua piracies: children/nodetype/printnode on EzXML.Node (src/utils.jl) — tracked in https://github.com/SciML/MathML.jl/issues/104
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using MathML, JET, Test
     # JET reports a genuine error: no matching method `mathml_to_nums(::EzXML.Node)` is
     # ever defined, yet mathml_to_nums(::EzXML.Document) calls it (src/utils.jl:20).
     # Tracked in https://github.com/SciML/MathML.jl/issues/104 — run in report mode and

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Pkg
+using SafeTestsets
 using MathML, EzXML, Symbolics, SpecialFunctions, IfElse, AbstractTrees, Test
 
 const GROUP = get(ENV, "GROUP", "All")
@@ -10,18 +11,18 @@ if GROUP == "QA"
     include("qa/qa.jl")
 else
     @testset "MathML.jl" begin
-        @testset "parsing" begin
+        @safetestset "parsing" begin
             include("parse.jl")
         end
-        @testset "utils" begin
+        @safetestset "utils" begin
             include("utils.jl")
         end
-        @testset "print" begin
+        @safetestset "print" begin
             include("print.jl")
         end
-        @testset "generate" begin
+        @safetestset "generate" begin
             include("generate.jl")
         end
-        # @testset "systems" begin include("sys.jl") end
+        # @safetestset "systems" begin include("sys.jl") end
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,3 +1,5 @@
+using MathML, EzXML, Test
+
 fn = "data/vinnakota_kemp_kushmeric_2006_exp45.cellml"
 doc = readxml(fn)
 docroot = doc.root


### PR DESCRIPTION
## What

Wraps each independent top-level test unit in `@safetestset` so it runs in its own freshly-generated module (matching the canonical OrdinaryDiffEq structure), giving isolation between units and world-age safety. No change to which tests run under which `GROUP`, no change to assertions.

## Changes

- **`test/runtests.jl`**: the four `"MathML.jl"` inner units (`parsing`, `utils`, `print`, `generate`) become `@safetestset "X" begin include("x.jl") end`. The `include()` form is required because `parse.jl` uses the package string macro `MathML"""..."""` and `@variables`; `include()` evaluates statements sequentially so `using MathML` / `using Symbolics` run before those macros are reached. The commented-out `systems`/`sys.jl` line was left commented (now `@safetestset`).
- **Self-contained included files**: `utils.jl`, `print.jl`, `generate.jl` each gained their own `using` lines (they previously relied on imports leaking from `runtests.jl`'s `Main`). `parse.jl` already imported everything it uses, so it was left as-is.
- **`test/qa/qa.jl`**: the plain `@testset "Aqua"` / `@testset "JET"` units become `@safetestset`, each carrying its own `using` block. The `@test_broken` lines (tracking #104) are preserved verbatim.
- **Deps**: added `SafeTestsets` to `[extras]` / `[targets].test` and `[compat] SafeTestsets = "0.1, 1"` in `Project.toml`, and to `test/qa/Project.toml` (the QA group activates its own env).

## Verification

`GROUP=Core` suite run locally on Julia 1.11: **36/36 pass**, all green under the new `@safetestset` structure.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)