### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,10 +29,9 @@ Test = "1"
 julia = "1.10"
 [extras]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ModelingToolkit", "Pkg", "SafeTestsets", "SciMLTesting"]
+test = ["Test", "ModelingToolkit", "SafeTestsets", "SciMLTesting"]

--- a/src/MathML.jl
+++ b/src/MathML.jl
@@ -2,9 +2,14 @@
 $(DocStringExtensions.README)
 """
 module MathML
-using DocStringExtensions
+using DocStringExtensions: DocStringExtensions
 
-using EzXML, Symbolics, Statistics, IfElse, AbstractTrees
+using EzXML: EzXML, ElementNode, TextNode, eachnode, elements, firstelement,
+    istext, link!, nodename, parsexml, readxml, setnodename!
+using Symbolics: Symbolics, @variables, Differential, Num, build_function
+using Statistics: Statistics
+using IfElse: IfElse
+using AbstractTrees: AbstractTrees
 import SpecialFunctions
 
 include("generate.jl")

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -38,6 +38,8 @@ function _symbol_to_MathML(e::Expr)
                 node = ElementNode("ci")
                 link!(node, TextNode(string(arg)))
             end
+        else
+            throw(ArgumentError("unsupported expression argument $(arg) of type $(typeof(arg))"))
         end
         link!(elm, node)
     end

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,4 +1,4 @@
-using PrecompileTools
+using PrecompileTools: @compile_workload, @setup_workload
 
 @setup_workload begin
     # Simple MathML strings for precompilation

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,6 +20,11 @@ function mathml_to_nums(xml::EzXML.Document)
     return mathml_to_nums(doc_root)
 end
 
+function mathml_to_nums(node::EzXML.Node)
+    cis = findall("//x:ci", node, ["x" => mathml_ns])
+    return unique(parse_ci.(cis))
+end
+
 """
     extract_mathml()
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -270,3 +270,14 @@ g = parse_lambda(xml)
 
 # parse_apply with <ci> as firstelement problem
 @test_throws KeyError parse_file("data/err.xml")
+
+# mathml_to_nums dispatches AbstractString -> Document -> Node, all yielding the
+# same Vector{Num} of the <ci> symbols (math.xml has compartment, k1, S1).
+@variables compartment k1 S1
+fn = "data/math.xml"
+doc = readxml(fn)
+nums_from_node = mathml_to_nums(doc.root)
+@test eltype(nums_from_node) == Num
+@test Set(nums_from_node) == Set([compartment, k1, S1])
+@test isequal(mathml_to_nums(doc), nums_from_node)
+@test isequal(mathml_to_nums(fn), nums_from_node)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,7 +2,6 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MathML = "abcecc63-2b08-419c-80c4-c63dca6fa478"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -12,7 +11,6 @@ MathML = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
-SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,19 +1,31 @@
-using MathML, Aqua, JET, Test
+using SciMLTesting, MathML, Test
+using JET
 
-@testset "Aqua" begin
-    # deps_compat (extras: Pkg has no [compat] entry) and piracies (children/nodetype/printnode
-    # on EzXML.Node) are genuine findings tracked in
-    # https://github.com/SciML/MathML.jl/issues/104 — run the rest of Aqua, mark these broken.
-    Aqua.test_all(MathML; deps_compat = false, piracies = false)
-    @test_broken false  # Aqua deps_compat: [extras] Pkg missing [compat] entry — tracked in https://github.com/SciML/MathML.jl/issues/104
-    @test_broken false  # Aqua piracies: children/nodetype/printnode on EzXML.Node (src/utils.jl) — tracked in https://github.com/SciML/MathML.jl/issues/104
-end
-
-@testset "JET" begin
-    # JET reports a genuine error: no matching method `mathml_to_nums(::EzXML.Node)` is
-    # ever defined, yet mathml_to_nums(::EzXML.Document) calls it (src/utils.jl:20).
-    # Tracked in https://github.com/SciML/MathML.jl/issues/104 — run in report mode and
-    # mark broken instead of failing the testset.
-    rep = JET.report_package(MathML; target_defined_modules = true)
-    @test_broken isempty(JET.get_reports(rep))  # JET: missing method mathml_to_nums(::EzXML.Node) — tracked in https://github.com/SciML/MathML.jl/issues/104
-end
+# Aqua piracies: `children`/`printnode`/`nodetype` are owned by AbstractTrees and
+# defined on EzXML.Node in src/utils.jl — neither name nor argument type is owned by
+# MathML, so Aqua flags type piracy. These are AbstractTrees-interface bindings for
+# walking EzXML trees and cannot be made non-pirate without an upstream/glue change;
+# tracked in https://github.com/SciML/MathML.jl/issues/104.
+#
+# ExplicitImports qualified-access ignores are all *other packages'* non-public
+# names that MathML legitimately uses:
+#   all_qualified_accesses_via_owners:
+#     toexpr     — owned by SymbolicUtils.Code, re-exported via Symbolics
+#   all_qualified_accesses_are_public:
+#     Document   — EzXML (not declared public)
+#     Node       — EzXML (not declared public)
+#     ifelse     — IfElse (not declared public)
+#     parse      — Base.Meta (not declared public)
+#     printnode  — AbstractTrees (not declared public)
+#     toexpr     — Symbolics (not declared public; SymbolicUtils-owned)
+run_qa(
+    MathML;
+    explicit_imports = true,
+    aqua_broken = (:piracies,),
+    ei_kwargs = (;
+        all_qualified_accesses_via_owners = (; ignore = (:toexpr,)),
+        all_qualified_accesses_are_public = (;
+            ignore = (:Document, :Node, :ifelse, :parse, :printnode, :toexpr),
+        ),
+    ),
+)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -15,7 +15,6 @@ using JET
 #     Document   — EzXML (not declared public)
 #     Node       — EzXML (not declared public)
 #     ifelse     — IfElse (not declared public)
-#     parse      — Base.Meta (not declared public)
 #     printnode  — AbstractTrees (not declared public)
 #     toexpr     — Symbolics (not declared public; SymbolicUtils-owned)
 run_qa(
@@ -25,7 +24,7 @@ run_qa(
     ei_kwargs = (;
         all_qualified_accesses_via_owners = (; ignore = (:toexpr,)),
         all_qualified_accesses_are_public = (;
-            ignore = (:Document, :Node, :ifelse, :parse, :printnode, :toexpr),
+            ignore = (:Document, :Node, :ifelse, :printnode, :toexpr),
         ),
     ),
 )


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Converts the hand-rolled `test/qa/qa.jl` (raw `Aqua.test_all` + `JET.report_package`) onto the SciMLTesting 1.6.0 `run_qa` entry point and enables ExplicitImports (`explicit_imports = true`).

### ExplicitImports findings (6 checks)

| check | outcome |
|---|---|
| `no_implicit_imports` | **FIXED** — all 24 implicit names made explicit (`using EzXML: ...`, `using Symbolics: ...`, `using PrecompileTools: @setup_workload, @compile_workload`, etc.) |
| `no_stale_explicit_imports` | pass |
| `all_explicit_imports_via_owners` | pass |
| `all_explicit_imports_are_public` | pass |
| `all_qualified_accesses_via_owners` | **ignore** `toexpr` (owned by `SymbolicUtils.Code`, re-exported via `Symbolics`) |
| `all_qualified_accesses_are_public` | **ignore** other packages' non-public names: `Document`/`Node` (EzXML), `ifelse` (IfElse), `parse` (`Base.Meta`), `printnode` (AbstractTrees), `toexpr` (Symbolics) |

### Aqua / JET

- **JET** finding (`mathml_to_nums(::EzXML.Node)` missing) is **FIXED**: the documented-but-unimplemented `EzXML.Node` method that the `Document`/`AbstractString` methods dispatch into is now defined. JET reports 0 errors, so the prior report-mode `@test_broken` is dropped and JET runs as a normal pass. A `parse.jl` test covers all three dispatch paths.
- **Aqua deps_compat** finding is **FIXED**: drop the unused `Pkg` from root `[extras]`/`[targets].test` (it was the only `[extras]` entry without a `[compat]` bound, and unused by the tests).
- **Aqua piracies** (`children`/`printnode`/`nodetype` on `EzXML.Node`) stays known-broken via `aqua_broken = (:piracies,)`, tracked in #104.

### Deps

- QA sub-env `SciMLTesting` compat bumped to `"1.6"`.
- ExplicitImports NOT added (transitive via SciMLTesting); Aqua kept (ambiguities child-proc); JET kept; unused `SafeTestsets` dropped from the QA env.
- `PrecompileTools` floor already `1.2.1` (self-contained macros), so the explicit macro import is downgrade-safe.

### Verification (released SciMLTesting 1.6.0, no dev-from-branch)

Resolved Aqua 0.8.16, JET 0.9.18/0.9.20, ExplicitImports 1.15.0.

- QA group: **17 pass / 1 broken (piracies) / 0 fail / 0 error** on Julia 1.10 (lts) and 1.11 (1).
- Core group: green (parse 37/37, generate 1/1, print 1/1, utils 1/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)