### PR TITLE
Bump version to 0.1.21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathML"
 uuid = "abcecc63-2b08-419c-80c4-c63dca6fa478"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["anand <anandj@uchicago.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (0.1.20 -> 0.1.21) to release unreleased commits on `main` via JuliaRegistrator.