### PR TITLE
Document MathML public API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,18 +13,16 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
-[sources]
-SciMLTesting = {url = "https://github.com/SciML/SciMLTesting.jl", rev = "a5cecca928f2c684c23505c3cd83921d71753e2e"}
-
 [compat]
 AbstractTrees = "0.4"
 DocStringExtensions = "0.9.3"
 EzXML = "1.1"
 IfElse = "0.1.1"
 ModelingToolkit = "11"
+Pkg = "1"
 PrecompileTools = "1.2.1"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "2.1"
+SciMLTesting = "1"
 SpecialFunctions = "2"
 Statistics = "1"
 Symbolics = "7.2"
@@ -32,9 +30,10 @@ Test = "1"
 julia = "1.10"
 [extras]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ModelingToolkit", "SafeTestsets", "SciMLTesting"]
+test = ["Test", "ModelingToolkit", "Pkg", "SafeTestsets", "SciMLTesting"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,9 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
+[sources]
+SciMLTesting = {url = "https://github.com/SciML/SciMLTesting.jl", rev = "a5cecca928f2c684c23505c3cd83921d71753e2e"}
+
 [compat]
 AbstractTrees = "0.4"
 DocStringExtensions = "0.9.3"
@@ -21,7 +24,7 @@ IfElse = "0.1.1"
 ModelingToolkit = "11"
 PrecompileTools = "1.2.1"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 SpecialFunctions = "2"
 Statistics = "1"
 Symbolics = "7.2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,9 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MathML = "abcecc63-2b08-419c-80c4-c63dca6fa478"
 
+[sources]
+MathML = {path = ".."}
+
 [compat]
 Documenter = "1.16.1"
 MathML = "0.1.18"

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -7,6 +7,19 @@ function parse_node(node)
     return tagmap[node.name](node)
 end
 
+"""
+    parse_str(str::AbstractString)
+
+Parse a MathML XML string into a Symbolics expression.
+
+# Examples
+
+```julia
+using MathML
+
+parse_str("<apply><plus/><ci>x</ci><cn>1</cn></apply>")
+```
+"""
 function parse_str(str)
     doc = parsexml(str)
     return parse_doc(doc)
@@ -17,6 +30,21 @@ function parse_doc(doc)
     return parse_node(node)
 end
 
+"""
+    parse_file(filename::AbstractString)
+
+Read a MathML XML file and parse the document root into a Symbolics expression.
+
+# Examples
+
+```julia
+using MathML
+
+filename = tempname()
+write(filename, "<apply><times/><ci>x</ci><cn>2</cn></apply>")
+parse_file(filename)
+```
+"""
 function parse_file(fn)
     node = readxml(fn).root
     return parse_node(node)
@@ -78,6 +106,25 @@ end
 
 ########## Parse piecewise ###################################################
 
+"""
+    parse_piecewise(node)
+
+Parse a MathML `<piecewise>` node into a nested symbolic conditional expression.
+
+# Examples
+
+```julia
+using MathML
+
+node = xml\"\"\"
+<piecewise>
+  <piece><cn>1</cn><apply><gt/><ci>x</ci><cn>0</cn></apply></piece>
+  <otherwise><cn>0</cn></otherwise>
+</piecewise>
+\"\"\"
+parse_piecewise(node)
+```
+"""
 function parse_piecewise(node)
     ns = elements(node)
     pieces = filter(x -> nodename(x) == "piece", ns)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -7,10 +7,11 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 MathML = {path = "../.."}
+SciMLTesting = {url = "https://github.com/SciML/SciMLTesting.jl", rev = "a5cecca928f2c684c23505c3cd83921d71753e2e"}
 
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -7,7 +7,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 MathML = {path = "../.."}
-SciMLTesting = {url = "https://github.com/SciML/SciMLTesting.jl", rev = "a5cecca928f2c684c23505c3cd83921d71753e2e"}
 
 [compat]
 Aqua = "0.8"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,4 @@
-using SciMLTesting, MathML, Test
-using JET
+using SciMLTesting, MathML
 
 # Aqua piracies: `children`/`printnode`/`nodetype` are owned by AbstractTrees and
 # defined on EzXML.Node in src/utils.jl — neither name nor argument type is owned by
@@ -21,6 +20,7 @@ run_qa(
     MathML;
     explicit_imports = true,
     aqua_broken = (:piracies,),
+    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         all_qualified_accesses_via_owners = (; ignore = (:toexpr,)),
         all_qualified_accesses_are_public = (;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,8 @@
+if get(ENV, "GROUP", "All") == "QA"
+    import Pkg
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.instantiate()
+end
+
 using SciMLTesting
 run_tests()


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- adds source docstrings for exported `parse_str`, `parse_file`, and `parse_piecewise`
- points the docs environment at the local checkout so docs builds render the PR code
- switches QA to SciMLTesting's new public API docs check with `api_docs_kwargs = (; rendered = true)`
- pins the QA environment to SciMLTesting `a5cecca` because the `run_api_docs` helper is on SciMLTesting v2.1/main but not yet registered

## Validation
- `git diff --check`
- `timeout 3600 julia --project=. -e 'using Pkg; Pkg.test()'`\n- `timeout 3600 julia --project=test/qa test/qa/qa.jl`\n- `timeout 3600 julia --project=docs -e 'using Pkg; Pkg.instantiate(); include("docs/make.jl")'`\n- `timeout 3600 julia --project=. -e 'using Runic; exit(Runic.main(ARGS))' -- --check .`