### PR TITLE
Use SciMLTesting v2.1 test runner

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,10 +19,9 @@ DocStringExtensions = "0.9.3"
 EzXML = "1.1"
 IfElse = "0.1.1"
 ModelingToolkit = "11"
-Pkg = "1"
 PrecompileTools = "1.2.1"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 SpecialFunctions = "2"
 Statistics = "1"
 Symbolics = "7.2"
@@ -30,10 +29,9 @@ Test = "1"
 julia = "1.10"
 [extras]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ModelingToolkit", "Pkg", "SafeTestsets", "SciMLTesting"]
+test = ["Test", "ModelingToolkit", "SafeTestsets", "SciMLTesting"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,9 +5,6 @@ MathML = "abcecc63-2b08-419c-80c4-c63dca6fa478"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-MathML = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,2 @@
-if get(ENV, "GROUP", "All") == "QA"
-    import Pkg
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    Pkg.instantiate()
-end
-
 using SciMLTesting
 run_tests()


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- require SciMLTesting v2.1 in the root test environment
- remove the manual QA Pkg activation bridge now handled by `run_tests()`
- drop the test-only Pkg dependency used only by that bridge

## Validation
- `timeout 3600 julia --project=. -e 'using Pkg; Pkg.test()'`\n- `JULIA_PKG_SERVER='\ GROUP=QA timeout 3600 julia --project=. -e 'using Pkg; Pkg.test()'`\n- `git diff --check`\n- `julia --project=. -e 'using TOML; foreach(TOML.parsefile, filter(isfile, ["Project.toml", "test/Project.toml", "test/qa/Project.toml", "test/Core/Project.toml"]))'`\n- `julia -m Runic --check test/runtests.jl`