### PR TITLE
Release prep: bump MathML to 0.1.22

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathML"
 uuid = "abcecc63-2b08-419c-80c4-c63dca6fa478"
-version = "0.1.21"
+version = "0.1.22"
 authors = ["anand <anandj@uchicago.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Patch release for accumulated docstring, QA, and test-scaffolding changes since 0.1.21 (no functional/API changes).