### PR TITLE
Use standard SciMLTesting QA docs check

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -20,7 +20,6 @@ run_qa(
     MathML;
     explicit_imports = true,
     aqua_broken = (:piracies,),
-    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         all_qualified_accesses_via_owners = (; ignore = (:toexpr,)),
         all_qualified_accesses_are_public = (;

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -18,7 +18,6 @@ using SciMLTesting, MathML
 #     toexpr     — Symbolics (not declared public; SymbolicUtils-owned)
 run_qa(
     MathML;
-    explicit_imports = true,
     aqua_broken = (:piracies,),
     ei_kwargs = (;
         all_qualified_accesses_via_owners = (; ignore = (:toexpr,)),


### PR DESCRIPTION
Removes the repository-specific rendered API-docs override. MathML already requires SciMLTesting `2.1+`; the standard QA configuration now owns this check.

Validated with Runic, the standard QA environment, and `Pkg.test()`.

Ignore until reviewed by @ChrisRackauckas.