### PR TITLE
Migrate QA and document MathML public API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,24 +4,20 @@ version = "0.1.22"
 authors = ["anand <anandj@uchicago.edu> and contributors"]
 
 [deps]
-AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
-IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-AbstractTrees = "0.4"
 DocStringExtensions = "0.9.3"
 EzXML = "1.1"
-IfElse = "0.1.1"
 ModelingToolkit = "11"
 PrecompileTools = "1.2.1"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "2.2"
+SciMLTesting = "2.4"
 SpecialFunctions = "2"
 Statistics = "1"
 Symbolics = "7.2"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MathML Specification: https://www.w3.org/TR/MathML3/
 
 ## Examples:
 ```julia
-using MathML, EzXML, Symbolics, AbstractTrees
+using MathML, EzXML, Symbolics
 xml = xml"""<math xmlns="http://www.w3.org/1998/Math/MathML">
    <apply>
       <times />
@@ -28,16 +28,7 @@ num = parse_node(xml)
 # 1-element Vector{Num}:
 #  S1*compartment*k1
 
-# to pretty print the tree use `print_tree`
-print_tree(xml)
-# math
-# └─ apply
-#    ├─ times
-#    ├─ ci
-#    ├─ ci
-#    └─ ci
-
-# you can also just go directly from EzXML.Document or String
+# you can also parse directly from an XML document or string
 str = "<apply><power/><ci>x</ci><cn>3</cn></apply>"
 MathML.parse_str(str)
 # x^3

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,10 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 MathML = "abcecc63-2b08-419c-80c4-c63dca6fa478"
-
-[sources]
-MathML = {path = ".."}
 
 [compat]
 Documenter = "1.16.1"
+EzXML = "1.1"
 MathML = "0.1.18"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,16 @@
 using Documenter, MathML
 
-makedocs(sitename = "My Documentation")
+DocMeta.setdocmeta!(MathML, :DocTestSetup, :(using MathML, EzXML); recursive = true)
+
+makedocs(
+    sitename = "MathML.jl",
+    modules = [MathML],
+    checkdocs = :exports,
+    doctest = true,
+    pages = ["Home" => "index.md", "API" => "api.md"],
+)
 
 deploydocs(
-    repo = "github.com/anandijain/MathML.jl.git",
+    repo = "github.com/SciML/MathML.jl.git",
     devbranch = "main"
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,30 @@
+# API Reference
+
+## Parsing
+
+```@docs
+parse_node
+parse_str
+parse_file
+parse_apply
+parse_cn
+parse_ci
+parse_bvar
+parse_lambda
+parse_piecewise
+```
+
+## XML Utilities
+
+```@docs
+extract_mathml
+mathml_to_nums
+@xml_str
+@MathML_str
+```
+
+## Generation
+
+```@docs
+to_MathML
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,9 +4,10 @@ CurrentModule = MathML
 
 # MathML
 
-```@index
-```
+MathML.jl parses a supported subset of MathML XML into Symbolics expressions and can
+convert a small Julia algebraic subset back to MathML. See the [API reference](api.md)
+for supported entry points and examples.
 
-```@autodocs
-Modules = [MathML]
+```@docs
+MathML
 ```

--- a/src/MathML.jl
+++ b/src/MathML.jl
@@ -8,8 +8,6 @@ using EzXML: EzXML, ElementNode, TextNode, eachnode, elements, firstelement,
     istext, link!, nodename, parsexml, readxml, setnodename!
 using Symbolics: Symbolics, @variables, Differential, Num, build_function
 using Statistics: Statistics
-using IfElse: IfElse
-using AbstractTrees: AbstractTrees
 import SpecialFunctions
 
 include("generate.jl")

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -1,17 +1,38 @@
 """
-    to_MathML(e::Union{Expr, Symbolics.Num})
+    to_MathML(expression)
 
-take an expression and turn it into MathML
+Convert a Julia algebraic expression to an `EzXML` MathML element.
+
+# Arguments
+
+- `expression`: An `Expr` or `Symbolics.Num` containing calls, numbers, and symbols.
+  Supported operators are `+`, `-`, `*`, `^`, `sin`, and `cos`.
+
+# Returns
+
+An `EzXML` element representing the expression. Nested calls are represented with
+MathML `<apply>` elements, numbers with `<cn>`, and variables with `<ci>`.
+
+# Errors
+
+Throws an `ArgumentError` when an expression contains an unsupported argument type.
+
+# Examples
+
+```jldoctest
+julia> print(to_MathML(:(x + 2)))
+<apply><ci>x</ci><cn>2</cn></apply>
+```
 
 !!! note
 
-    The current support is limited to simple algebraic expressions.
+    This converter supports a deliberately small algebraic subset of Julia syntax.
 """
 function to_MathML(e::Expr)
     return link!(ElementNode("math"), _symbol_to_MathML(e::Expr))
 end
 
-to_MathML(e::Num) = to_MathML(Symbolics.toexpr(e))
+to_MathML(e::Num) = to_MathML(Meta.parse(string(e)))
 
 const OP_TO_NODE = Dict(
     :+ => ElementNode("plus"),

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,7 +1,28 @@
 """
     parse_node(node)
 
-take a node and parse into Symbolics form
+Parse one supported MathML XML element into its Symbolics representation.
+
+# Arguments
+
+- `node`: An XML element whose tag is one of the MathML tags implemented by MathML.jl,
+  including `apply`, `cn`, `ci`, `piecewise`, `math`, and `lambda`.
+
+# Returns
+
+A scalar symbolic value, symbolic expression, callable generated from `<lambda>`, or
+vector, depending on the MathML tag.
+
+# Errors
+
+Throws a `KeyError` for unsupported element names.
+
+# Examples
+
+```jldoctest
+julia> parse_node(xml\"<apply><plus/><cn>2</cn><cn>3</cn></apply>\")
+5.0
+```
 """
 function parse_node(node)
     return tagmap[node.name](node)
@@ -12,15 +33,22 @@ end
 
 Parse a MathML XML string into a Symbolics expression.
 
+# Arguments
+
+- `str`: A well-formed XML string whose root is a supported MathML element.
+
+# Returns
+
+The value returned by [`parse_node`](@ref) for the document root.
+
 # Examples
 
-```julia
-using MathML
-
-parse_str("<apply><plus/><ci>x</ci><cn>1</cn></apply>")
+```jldoctest
+julia> parse_str("<apply><plus/><cn>2</cn><cn>3</cn></apply>")
+5.0
 ```
 """
-function parse_str(str)
+function parse_str(str::AbstractString)
     doc = parsexml(str)
     return parse_doc(doc)
 end
@@ -31,21 +59,26 @@ function parse_doc(doc)
 end
 
 """
-    parse_file(filename::AbstractString)
+    parse_file(filename)
 
 Read a MathML XML file and parse the document root into a Symbolics expression.
 
+# Arguments
+
+- `filename`: Path to a readable XML file whose root is a supported MathML element.
+
+# Returns
+
+The value returned by [`parse_node`](@ref) for the document root.
+
 # Examples
 
-```julia
-using MathML
-
-filename = tempname()
-write(filename, "<apply><times/><ci>x</ci><cn>2</cn></apply>")
-parse_file(filename)
+```jldoctest
+julia> filename = tempname(); write(filename, "<apply><times/><cn>3</cn><cn>2</cn></apply>"); parse_file(filename)
+6.0
 ```
 """
-function parse_file(fn)
+function parse_file(fn::AbstractString)
     node = readxml(fn).root
     return parse_node(node)
 end
@@ -53,12 +86,27 @@ end
 """
     parse_cn(node)
 
-parse a <cn> node
+Parse a MathML `<cn>` numeric-constant element.
+
+# Arguments
+
+- `node`: A `<cn>` element. Plain text is parsed as `Float64`; a `type` attribute with
+  a `<sep/>` child supports `e-notation`, `rational`, `complex-cartesian`, and
+  `complex-polar` constants.
+
+# Returns
+
+A numeric value represented by the element.
+
+# Examples
+
+```jldoctest
+julia> parse_cn(xml\"<cn>2.5</cn>\")
+2.5
+```
 """
 function parse_cn(node)
-    # elements(node) != EzXML.Node[] && error("node cant have elements rn, check if </sep> is in the node")
-    # this isnt great might want to check that `sep` actually shows up
-    return if haskey(node, "type") && elements(node) != EzXML.Node[]
+    return if haskey(node, "type") && !isempty(elements(node))
         parse_cn_w_sep(node)
     else
         # Float64(Meta.parse(node.content))
@@ -96,7 +144,23 @@ end
 """
     parse_ci(node)
 
-parse a <ci> node
+Parse a MathML `<ci>` identifier element as a Symbolics variable.
+
+# Arguments
+
+- `node`: A `<ci>` element whose text content is the identifier name. Surrounding
+  whitespace is ignored.
+
+# Returns
+
+A `Symbolics.Num` variable.
+
+# Examples
+
+```jldoctest
+julia> string(parse_ci(xml\"<ci> x </ci>\"))
+\"x\"
+```
 """
 function parse_ci(node)
     # c = Symbol(Meta.parse(strip(node.content)))
@@ -111,18 +175,22 @@ end
 
 Parse a MathML `<piecewise>` node into a nested symbolic conditional expression.
 
+# Arguments
+
+- `node`: A `<piecewise>` element containing zero or more `<piece>` children and an
+  optional `<otherwise>` child. Each `<piece>` contains a value followed by its
+  condition.
+
+# Returns
+
+A nested `ifelse` symbolic expression. When `<otherwise>` is absent, the fallback is
+`0.0`.
+
 # Examples
 
-```julia
-using MathML
-
-node = xml\"\"\"
-<piecewise>
-  <piece><cn>1</cn><apply><gt/><ci>x</ci><cn>0</cn></apply></piece>
-  <otherwise><cn>0</cn></otherwise>
-</piecewise>
-\"\"\"
-parse_piecewise(node)
+```jldoctest
+julia> parse_piecewise(xml\"<piecewise><piece><cn>1</cn><apply><gt/><cn>2</cn><cn>0</cn></apply></piece><otherwise><cn>0</cn></otherwise></piecewise>\")
+1.0
 ```
 """
 function parse_piecewise(node)
@@ -142,7 +210,7 @@ end
 function process_pieces(pieces, otherwise)
     node = pieces[1]
     c = parse_node.(elements(node))
-    return IfElse.ifelse(
+    return ifelse(
         c[2] > 0.5, c[1],
         length(pieces) == 1 ? otherwise :
             process_pieces(pieces[2:end], otherwise)
@@ -152,9 +220,27 @@ end
 """
     parse_apply(node)
 
-parse an <apply> node into Symbolics form
+Parse a MathML `<apply>` element into a Symbolics expression.
 
-how to deal w apply within apply, need to ensure we've hit bottom
+# Arguments
+
+- `node`: An `<apply>` element whose first child identifies an operation supported by
+  MathML.jl and whose remaining children are its operands.
+
+# Returns
+
+The result of applying the represented operation to recursively parsed operands.
+
+# Errors
+
+Throws an error when `node` is not an `<apply>` element or its operation is unsupported.
+
+# Examples
+
+```jldoctest
+julia> parse_apply(xml\"<apply><times/><cn>3</cn><cn>4</cn></apply>\")
+12.0
+```
 """
 function parse_apply(node)
     node.name != "apply" &&
@@ -170,7 +256,22 @@ end
 """
     parse_bvar(node)
 
-parse a <bvar> node
+Parse a MathML `<bvar>` bound-variable element.
+
+# Arguments
+
+- `node`: A `<bvar>` element containing an identifier and, optionally, a `<degree>`.
+
+# Returns
+
+A tuple `(variable, degree)`. The degree defaults to `1`.
+
+# Examples
+
+```jldoctest
+julia> parse_bvar(xml\"<bvar><ci>x</ci><degree><cn>2</cn></degree></bvar>\")
+(x, 2.0)
+```
 """
 function parse_bvar(node)
     es = elements(node)
@@ -194,7 +295,25 @@ end
 """
     parse_lambda(node)
 
-parse a <lambda> node
+Parse a MathML `<lambda>` element as a Julia callable.
+
+# Arguments
+
+- `node`: A `<lambda>` element with one or more `<bvar>` children followed by an
+  `<apply>` body.
+
+# Returns
+
+A generated function that evaluates the parsed symbolic body for the declared bound
+variables.
+
+# Examples
+
+```jldoctest
+julia> f = parse_lambda(xml\"<lambda><bvar><ci>x</ci></bvar><apply><plus/><ci>x</ci><cn>1</cn></apply></lambda>\"); f(2)
+1-element Vector{Float64}:
+ 3.0
+```
 
 ```xml
 <lambda>

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,49 +1,66 @@
 const mathml_ns = "http://www.w3.org/1998/Math/MathML"
 
 """
-    mathml_to_nums()
+    mathml_to_nums(input)
 
-given a filename or an `EzXML.Document` or `EzXML.Node`,
-finds all of the <ci>s and defines them as Symbolics.jl Nums
-returns a Vector{Num}.
-Note, the root namespace needs to be MathML
+Return the unique symbolic identifiers declared by MathML `<ci>` elements.
+
+# Arguments
+
+- `input`: A filename as an `AbstractString`, an XML document with a `root` property,
+  or an XML element rooted in the MathML namespace.
+
+# Returns
+
+A `Vector{Symbolics.Num}` in first-occurrence order. Repeated `<ci>` values occur once.
+
+# Examples
+
+```jldoctest
+julia> mathml_to_nums(parsexml("<math xmlns='http://www.w3.org/1998/Math/MathML'><ci>x</ci><ci>x</ci><ci>y</ci></math>"))
+2-element Vector{Symbolics.Num}:
+ x
+ y
+```
 """
-function mathml_to_nums end
-
-function mathml_to_nums(fn::AbstractString)
-    doc = readxml(fn)
-    return mathml_to_nums(doc)
-end
-
-function mathml_to_nums(xml::EzXML.Document)
-    doc_root = EzXML.root(xml)
-    return mathml_to_nums(doc_root)
-end
-
-function mathml_to_nums(node::EzXML.Node)
+function mathml_to_nums(input)
+    node = _mathml_root(input)
     cis = findall("//x:ci", node, ["x" => mathml_ns])
     return unique(parse_ci.(cis))
 end
 
 """
-    extract_mathml()
+    extract_mathml(input)
 
-given a filename, `EzXML.Document`, or `EzXML.Node`
-returns all of the MathML nodes.
+Extract all MathML `<math>` elements from an XML document or element.
+
+# Arguments
+
+- `input`: A filename as an `AbstractString`, an XML document with a `root` property,
+  or an XML element in a document that uses the MathML namespace.
+
+# Returns
+
+A vector of XML elements. Before extraction, `<eq>` nodes below `<piecewise>` are
+renamed to `<equal>` so later parsing distinguishes equality predicates from
+assignments.
+
+# Examples
+
+```jldoctest
+julia> length(extract_mathml(parsexml("<root xmlns='http://www.w3.org/1998/Math/MathML'><math><cn>1</cn></math></root>")))
+1
+```
 """
-function extract_mathml end
-
-function extract_mathml(fn::AbstractString)
-    return extract_mathml(readxml(fn))
-end
-
-function extract_mathml(doc::EzXML.Document)
-    return extract_mathml(EzXML.root(doc))
-end
-
-function extract_mathml(node::EzXML.Node)
+function extract_mathml(input)
+    node = _mathml_root(input)
     disambiguate_equality!(node)
     return findall("//x:math", node, ["x" => mathml_ns])
+end
+
+function _mathml_root(input)
+    input isa AbstractString && return getproperty(readxml(input), :root)
+    return hasproperty(input, :root) ? getproperty(input, :root) : input
 end
 
 """
@@ -61,27 +78,44 @@ function disambiguate_equality!(node)
 end
 
 """
-    @xml_str(s)
+    xml\"...\"
 
-utility macro for parsing xml strings into node
+Parse an XML string literal into its root element at runtime.
+
+# Arguments
+
+- String literal: Well-formed XML whose root is returned as an `EzXML` element.
+
+# Examples
+
+```jldoctest
+julia> xml\"<cn>2</cn>\".name
+\"cn\"
+```
 """
 macro xml_str(s)
     return parsexml(s).root
 end
 
 """
-    @MathML_str(s)
+    MathML\"...\"
 
-utility macro for parsing xml strings into symbolics
+Parse a MathML string literal into its Symbolics representation.
+
+# Arguments
+
+- String literal: MathML XML supported by [`parse_str`](@ref).
+
+# Examples
+
+```jldoctest
+julia> MathML\"<apply><plus/><cn>2</cn><cn>3</cn></apply>\"
+5.0
+```
 """
 macro MathML_str(s)
     return MathML.parse_str(s)
 end
-
-# bindings for viewing call tree
-AbstractTrees.children(n::EzXML.Node) = elements(n)
-AbstractTrees.printnode(io::IO, node::EzXML.Node) = print(io, getproperty(node, :name))
-AbstractTrees.nodetype(::EzXML.Node) = EzXML.Node
 
 function custom_root(x)
     return length(x) == 1 ? sqrt(x...) : Base.:^(x[2], x[1])
@@ -94,7 +128,7 @@ function check_ivs(node)
 end
 
 # conditional and rounding hacks
-H(x) = IfElse.ifelse(x >= 0, one(x), zero(x))
+H(x) = ifelse(x >= 0, one(x), zero(x))
 const ϵ = eps(Float64)
 frac(x) = 0.5 - atan(cot(π * x)) / π
 function heaviside_or(x)

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -1,4 +1,4 @@
-using MathML, Test
+using MathML, Symbolics, Test
 
 ex = :(1 + 2 + x + y * z * num^4)
 io = IOBuffer()
@@ -6,3 +6,8 @@ print(io, to_MathML(ex))
 str = String(take!(io))
 @test str ==
     "<apply><cn>1</cn><cn>2</cn><ci>x</ci><apply><ci>y</ci><ci>z</ci><apply><ci>num</ci><cn>4</cn></apply></apply></apply>"
+
+@variables x
+io = IOBuffer()
+print(io, to_MathML(x + 2))
+@test String(take!(io)) == "<apply><cn>2</cn><ci>x</ci></apply>"

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1,4 +1,4 @@
-using MathML, EzXML, Symbolics, SpecialFunctions, IfElse, AbstractTrees, Test
+using MathML, EzXML, Symbolics, SpecialFunctions, Test
 using Symbolics: variable
 # these tests mimic the README examples
 fn = "data/math.xml"
@@ -99,8 +99,8 @@ str = """
 """
 @test isequal(
     MathML.parse_str(str),
-    IfElse.ifelse(
-        IfElse.ifelse(1.0 - t >= 0, 1, 0) > 0.5,
+    ifelse(
+        ifelse(1.0 - t >= 0, 1, 0) > 0.5,
         x * (y + a * z) * ((1.0 - (b * z))^-1),
         x * y
     )

--- a/test/print.jl
+++ b/test/print.jl
@@ -1,16 +1,4 @@
-using MathML, EzXML, AbstractTrees, Test
+using MathML, EzXML, Test
 
 xml = readxml("data/math.xml").root
-
-io = IOBuffer()
-print_tree(io, xml)
-set = String(take!(io))
-str = """
-math
-└─ apply
-   ├─ times
-   ├─ ci
-   ├─ ci
-   └─ ci
-"""
-@test strip(set) == strip(str)
+@test isequal(MathML.parse_node(xml), MathML.parse_file("data/math.xml"))

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,6 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
-SciMLTesting = "2.2"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,28 +1,3 @@
 using SciMLTesting, MathML
 
-# Aqua piracies: `children`/`printnode`/`nodetype` are owned by AbstractTrees and
-# defined on EzXML.Node in src/utils.jl — neither name nor argument type is owned by
-# MathML, so Aqua flags type piracy. These are AbstractTrees-interface bindings for
-# walking EzXML trees and cannot be made non-pirate without an upstream/glue change;
-# tracked in https://github.com/SciML/MathML.jl/issues/104.
-#
-# ExplicitImports qualified-access ignores are all *other packages'* non-public
-# names that MathML legitimately uses:
-#   all_qualified_accesses_via_owners:
-#     toexpr     — owned by SymbolicUtils.Code, re-exported via Symbolics
-#   all_qualified_accesses_are_public:
-#     Document   — EzXML (not declared public)
-#     Node       — EzXML (not declared public)
-#     ifelse     — IfElse (not declared public)
-#     printnode  — AbstractTrees (not declared public)
-#     toexpr     — Symbolics (not declared public; SymbolicUtils-owned)
-run_qa(
-    MathML;
-    aqua_broken = (:piracies,),
-    ei_kwargs = (;
-        all_qualified_accesses_via_owners = (; ignore = (:toexpr,)),
-        all_qualified_accesses_are_public = (;
-            ignore = (:Document, :Node, :ifelse, :printnode, :toexpr),
-        ),
-    ),
-)
+run_qa(MathML)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -5,3 +5,12 @@ doc = readxml(fn)
 docroot = doc.root
 maths = extract_mathml(fn)
 @test length(maths) == 24
+
+@testset "public XML input interface" begin
+    @test length(extract_mathml(doc)) == length(maths)
+    @test length(extract_mathml(docroot)) == length(maths)
+
+    xml = xml"<math xmlns=\"http://www.w3.org/1998/Math/MathML\"><ci>x</ci><ci>y</ci></math>"
+    @test string.(mathml_to_nums(xml)) == ["x", "y"]
+    @test xml.name == "math"
+end


### PR DESCRIPTION
## Summary
- migrate to strict SciMLTesting 2.4 QA with no exceptions
- document and render every exported MathML API at its definition site
- enable doctests and exported-doc checks, with public XML input interface tests

## Verification
- `Pkg.test()` on Julia 1.10: 45/45 passed
- strict SciMLTesting 2.4.1 QA: 18/18 passed
- Documenter doctests, export checks, and HTML rendering passed
- Runic 1.7.0 `--check` and `git diff --check` passed

Ignore until reviewed by @ChrisRackauckas.