### PR TITLE
Fix EzXML minimum compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 DocStringExtensions = "0.9.3"
-EzXML = "1.1"
+EzXML = "1.2"
 ModelingToolkit = "11"
 PrecompileTools = "1.2.1"
 SafeTestsets = "0.1, 1"


### PR DESCRIPTION
Raises MathML's EzXML compat floor from 1.1 to 1.2.

EzXML 1.1 does not expose `propertynames(::Document)`, so MathML's `hasproperty(doc, :root)` check leaves an `EzXML.Document` unwrapped and the three-argument `findall` call errors. EzXML 1.2 adds that property contract.

Validation:
- Julia 1.10, EzXML 1.1.0: reproduced the published downgrade failure.
- Julia 1.10, locked EzXML 1.2.0: full test suite passed (45 tests).
- Fresh `action-downgrade-compat` deps resolution selected EzXML 1.2.0; locked full suite passed (45 tests).

Draft — please ignore until reviewed by @ChrisRackauckas.