### PR TITLE
Raise ModelingToolkit test floor to 11.21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 DocStringExtensions = "0.9.3"
 EzXML = "1.2"
-ModelingToolkit = "11"
+ModelingToolkit = "11.21"
 PrecompileTools = "1.2.1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` lower-bound bump:

- `ModelingToolkit = "11"` → `ModelingToolkit = "11.21"`

No library code or package version changed.

## Why

A declared ModelingToolkit 11.x floor of `11` pins **11.0.0** under julia-downgrade-compat. On Julia 1.10 that release fails to precompile:

```
ERROR: LoadError: UndefVarError: `ispublic` not defined
  @ ModelingToolkit src/ModelingToolkit.jl:115
```

Isolated Julia 1.10.11: `Pkg.add(name="ModelingToolkit", version="11.0.0")` resolves, then precompile dies (tree-sha `zsgrz`). 11.1.0 still hits `ispublic`. 11.21.0 loads (same floor as CellMLToolkit / Corleone / CatalystNetworkAnalysis).

## Verification

| ModelingToolkit | Result |
|---|---|
| 11.0.0 (old 11.x floor) | precompile `UndefVarError: ispublic` |
| 11.21.0 (new floor) | `using ModelingToolkit` OK |

Not verified: a live `julia-downgrade-compat` run on this checkout after the bump.
